### PR TITLE
Loader updates for Java 9+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,11 @@ matrix:
     osx_image: xcode9.4
 addons:
   homebrew:
+    taps: AdoptOpenJDK/openjdk
+    casks: adoptopenjdk8
     packages:
       - gnupg2
-      - swig
+      - adoptopenjdk8
     update: true
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,6 @@ after_success:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export GPG_TTY=`tty`; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gpg-agent; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PINENTRY_MODE="--pinentry-mode=loopback"; fi
+- unzip -l target/jvrpn-*-natives-*.jar
 - deploy/before-deploy.sh
 - deploy/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,29 +13,29 @@ matrix:
     sudo: false
     addons:
       apt:
-        sources:
-        - sourceline: ppa:george-edison55/precise-backports
-        - sourceline: ppa:ubuntu-toolchain-r/test
-        - llvm-toolchain-precise-3.6
         packages:
         - cmake
         - cmake-data
-        - clang-3.6
+        - clang-3.8
         - gnupg2
+        - openjdk-8-jdk-headless
   - os: osx
-    osx_image: xcode7.3
+    osx_image: xcode9.3
+addons:
+  homebrew:
+    packages:
+      - gnupg2
+      - swig
+    update: true
 cache:
   directories:
   - "$HOME/.m2"
 install:
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew unlink gnupg; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gnupg2; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/libexec/java_home -V; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo "UPDATESTARTUPTTY" | gpg-connect-agent > /dev/null 2>&1; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export COMPILER=clang++-3.6; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=clang++-3.6; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CC=clang-3.6; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export COMPILER=clang++-3.8; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=clang++-3.8; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CC=clang-3.8; fi
 - git submodule init
 - git submodule update
 script:
@@ -44,12 +44,14 @@ script:
 - cmake .. -DVRPN_BUILD_SERVERS=0
 - cmake --build . --config Release
 - cd ../../../
-- mvn package
+- mvn -B package
 after_success:
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then killall -9 gpg-agent; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export GPG_TTY=`tty`; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gpg-agent; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PINENTRY_MODE="--pinentry-mode=loopback"; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf; fi
+- killall -9 gpg-agent
+- export GPG_TTY=`tty`
+- gpg-agent
+- export PINENTRY_MODE="--pinentry-mode=loopback"
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s `which gpg` /usr/local/bin/gpg2; fi
 - unzip -l target/jvrpn-*-natives-*.jar
 - deploy/before-deploy.sh
 - deploy/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ cache:
   - "$HOME/.m2"
 install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/libexec/java_home -V; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export JAVA_HOME=$(/usr/libexec/java_home -v1.8); fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo "UPDATESTARTUPTTY" | gpg-connect-agent > /dev/null 2>&1; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export COMPILER=clang++-3.8; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=clang++-3.8; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         - gnupg2
         - openjdk-8-jdk-headless
   - os: osx
-    osx_image: xcode9.3
+    osx_image: xcode9.4
 addons:
   homebrew:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 matrix:
   include:
   - os: linux
-    jdk: oraclejdk8
+    jdk: openjdk8
     sudo: false
     addons:
       apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,7 @@ after_build:
 on_success:
   - cmd: SET PATH=C:\gnupg2;%PATH%
   - ps: $env:Path += ";C:\gnupg2"
+  - cmd: unzip -l target/jvrpn-*-natives-*.jar
   - cmd: if "%APPVEYOR_PULL_REQUEST_TITLE%" == "" if "%APPVEYOR_REPO_BRANCH%" == "master" secure-file\tools\secure-file -decrypt deploy\codesigning-appveyor.asc.enc -secret "%CERTIFICATE_KEY%"
   - cmd: if "%APPVEYOR_PULL_REQUEST_TITLE%" == "" if "%APPVEYOR_REPO_BRANCH%" == "master" gpg2 --fast-import deploy/codesigning-appveyor.asc
   - cmd: if "%APPVEYOR_PULL_REQUEST_TITLE%" == "" if "%APPVEYOR_REPO_BRANCH%" == "master" bash.exe deploy/deploy.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ install:
   - cmd: SET JAVA_OPTS=-Xmx2g
   - cmd: mvn --version
   - cmd: java -version
-  - cmd: choco install swig
   - ps: .\deploy\install-gnupg.ps1
   - cmd: nuget install secure-file -ExcludeVersion
   - cmd: SET PATH=C:\gnupg2;%PATH%

--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.scijava</groupId>
-        <artifactId>pom-scijava</artifactId>
-        <version>10.6.0</version>
-    </parent>
 
     <groupId>graphics.scenery</groupId>
     <artifactId>jvrpn</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
+    <inceptionYear>2016</inceptionYear>
 
-    <name>VRPN bindings for the JavaVM</name>
+    <name>jvrpn</name>
+    <description>Java bindings for VRPN</description>
+    <url>http://scenery.graphics</url>
+    <organization>
+        <name>scenery</name>
+        <url>http://scenery.graphics</url>
+    </organization>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
+    <developers>
+        <developer>
+            <id>skalarproduktraum</id>
+            <name>Ulrik Günther</name>
+            <email>hello@ulrik.is</email>
+            <url>http://ulrik.is/</url>
+            <roles>
+                <role>lead</role>
+                <role>developer</role>
+            </roles>
+            <timezone>+1</timezone>
+        </developer>
+    </developers>
 
     <scm>
         <connection>scm:git:git://github.com/scenerygraphics/jvrpn</connection>
         <developerConnection>scm:git:git@github.com:scenerygraphics/jvrpn</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/scenerygraphics/jvrpn</url>
+        <url>http://scenery.graphics</url>
     </scm>
     <issueManagement>
         <system>GitHub</system>
@@ -32,8 +49,16 @@
     </issueManagement>
     <ciManagement>
         <system>Travis</system>
-        <url>http://travis-ci.org/scenerygraphics/jvrpn/</url>
+        <url>https://travis-ci.org/scenerygraphics/jvrpn/</url>
     </ciManagement>
+
+    <licenses>
+        <license>
+            <name>BSD 2-Clause License</name>
+            <url>http://opensource.org/licenses/BSD-2-Clause</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <distributionManagement>
         <snapshotRepository>
@@ -62,6 +87,7 @@
                         <version>3.0.2</version>
                         <executions>
                             <execution>
+                                <id>windows</id>
                                 <phase>package</phase>
                                 <goals>
                                     <goal>jar</goal>
@@ -69,11 +95,113 @@
                                 <configuration>
                                     <classifier>natives-windows</classifier>
                                     <includes>
-                                        <include>**/*.dll</include>
+                                        <include>*.dll</include>
                                     </includes>
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>add-resource</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>add-resource</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>external/vrpn/build/java_vrpn/Release</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>platform-linux</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.0.2</version>
+                        <executions>
+                            <execution>
+                                <id>linux</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>natives-linux</classifier>
+                                    <includes>
+                                        <include>*.so</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>add-resource</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>add-resource</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>external/vrpn/build/java_vrpn</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>-v</arg>
+                                <arg>--batch</arg>
+                                <arg>${env.PINENTRY_MODE}</arg>
+                            </gpgArguments>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
@@ -102,83 +230,6 @@
                         </executions>
                     </plugin>
                 </plugins>
-
-                <resources>
-                    <resource>
-                        <directory>external/vrpn/build/java_vrpn/Release</directory>
-                        <includes>
-                            <include>**/*.dll</include>
-                        </includes>
-                    </resource>
-                </resources>
-            </build>
-        </profile>
-        <profile>
-            <id>platform-linux</id>
-            <activation>
-                <os>
-                    <family>linux</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <version>3.0.2</version>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                                <configuration>
-                                    <classifier>natives-linux</classifier>
-                                    <includes>
-                                        <include>**/*.so</include>
-                                    </includes>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-
-                <resources>
-                    <resource>
-                        <directory>external/vrpn/build/java_vrpn</directory>
-                        <includes>
-                            <include>**/*.so</include>
-                        </includes>
-                    </resource>
-                </resources>
-            </build>
-        </profile>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <gpgArguments>
-                                <arg>-v</arg>
-                                <arg>--batch</arg>
-                                <arg>${env.PINENTRY_MODE}</arg>
-                            </gpgArguments>
-                        </configuration>
-                    </plugin>
-                </plugins>
             </build>
         </profile>
         <profile>
@@ -196,6 +247,7 @@
                         <version>3.0.2</version>
                         <executions>
                             <execution>
+                                <id>macos</id>
                                 <phase>package</phase>
                                 <goals>
                                     <goal>jar</goal>
@@ -203,30 +255,40 @@
                                 <configuration>
                                     <classifier>natives-macos</classifier>
                                     <includes>
-                                        <include>**/*.dylib</include>
-                                        <include>**/*.jnilib</include>
+                                        <include>*.dylib</include>
+                                        <include>*.jnilib</include>
                                     </includes>
                                 </configuration>
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>add-resource</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>add-resource</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>external/vrpn/build/java_vrpn</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
-
-                <resources>
-                    <resource>
-                        <directory>external/vrpn/build/java_vrpn</directory>
-                        <includes>
-                            <include>**/*.dylib</include>
-                            <include>**/*.jnilib</include>
-                        </includes>
-                    </resource>
-                </resources>
             </build>
         </profile>
     </profiles>
 
     <build>
-        <sourceDirectory>external/vrpn/java_vrpn/vrpn</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -238,6 +300,33 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <!-- NB: Exclude native libraries from sources JAR. -->
+                            <excludes>
+                                <exclude>*.*</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <!-- NB: Override default execution of the main JAR. -->
+                        <id>default-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <!-- NB: Nesting config in this execution excludes native libraries from the main JAR only. -->
+                            <excludes>
+                                <exclude>*.*</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -264,45 +353,29 @@
                 <version>2.8.1</version>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/main/loader</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
-
-        <resources>
-            <resource>
-                <directory>src</directory>
-                <excludes>
-                    <exclude>natives/**</exclude>
-                </excludes>
-            </resource>
-        </resources>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 </project>


### PR DESCRIPTION
This PR updates the Native Lib Loader to use `System.load()` instead of ugly hacks and `System.loadLibrary()`.